### PR TITLE
Remove Singleton Implementation and More!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ if(EVENTBUS_BUILD_TESTS)
             "INSTALL_GTEST OFF"
             "gtest_force_shared_crt ON"
     )
+    # this needs to be in the top level directory
+    # before any calls to `add_subdirectory()` for
+    # ctest to be set up properly
+    enable_testing()
 endif()
 
 add_subdirectory(eventbus)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -46,44 +46,46 @@ public:
 int main()
 {
 	using namespace dp;
+	event_bus evt_bus;
 	my_callback_object callback_obj;
 
 	auto fo = &foo;
-	const auto reg = event_bus::register_handler<dummy_event>(&foo);
-	const auto third_event_reg = event_bus::register_handler<third_event>([](const third_event& evt)
+	const auto reg = evt_bus.register_handler<dummy_event>(&foo);
+	const auto third_event_reg = evt_bus.register_handler<third_event>([](const third_event& evt)
 	{
 			std::cout << "my third event handler: " << evt.value << new_line;
 	});
 
-	const auto empty_event_handler = event_bus::register_handler<third_event>([]() {std::cout << "I just do stuff when a third_event is fired." << new_line; });
+	const auto empty_event_handler = evt_bus.register_handler<third_event>([]() {std::cout << "I just do stuff when a third_event is fired." << new_line; });
 	
 	dummy_event evt{ "hello from dummy event" };
-	event_bus::fire_event(&evt);
-	event_bus::fire_event(third_event{ 13.0 });
-	event_bus::remove_handler(third_event_reg);
-	event_bus::fire_event(third_event{ 13.0 });
+	evt_bus.fire_event(&evt);
+	evt_bus.fire_event(third_event{ 13.0 });
+	evt_bus.remove_handler(third_event_reg);
+	evt_bus.fire_event(third_event{ 13.0 });
 	
-	const auto other_event_reg = event_bus::register_handler<other_event>([](const other_event& evt) {std::cout << "first other event handler says: " << evt.message << std::endl; });
-	const auto other_event_second_reg = event_bus::register_handler<other_event>([](const other_event& evt){std::cout << "second other event handler says: " << evt.id << " " << evt.message << std::endl;});
-	const auto dmy_evt_first_reg = event_bus::register_handler<dummy_event>([](const dummy_event& evt) {std::cout << "wow it works!" << std::endl;});
-	const auto dmy_evt_pmr_reg = event_bus::register_handler<dummy_event>(&callback_obj , &my_callback_object::on_event_fired);
-	const auto thrid_event_reg_pmr = event_bus::register_handler<third_event>(&callback_obj, &my_callback_object::on_third_event);
+	
+	const auto other_event_reg = evt_bus.register_handler<other_event>([](const other_event& evt) {std::cout << "first other event handler says: " << evt.message << std::endl; });
+	const auto other_event_second_reg = evt_bus.register_handler<other_event>([](const other_event& evt){std::cout << "second other event handler says: " << evt.id << " " << evt.message << std::endl;});
+	const auto dmy_evt_first_reg = evt_bus.register_handler<dummy_event>([](const dummy_event& evt) {std::cout << "wow it works!" << std::endl;});
+	const auto dmy_evt_pmr_reg = evt_bus.register_handler<dummy_event>(&callback_obj , &my_callback_object::on_event_fired);
+	const auto thrid_event_reg_pmr = evt_bus.register_handler<third_event>(&callback_obj, &my_callback_object::on_third_event);
 
 	// the following does not compile
 	// third_event_object teo;
-	// const auto rg = event_bus::register_handler<third_event>(&teo, &my_callback_object::on_third_event);
+	// const auto rg = evt_bus.register_handler<third_event>(&teo, &my_callback_object::on_third_event);
 	
 	other_event other_evt{ 2, "hello there" };
 	dummy_event dmy_event{ "oh boy..." };
 	
-	event_bus::fire_event(dmy_event);
+	evt_bus.fire_event(dmy_event);
 
 	std::cout << "Firing other event\n";
-	event_bus::fire_event(other_evt);
-	event_bus::remove_handler(other_event_reg);
+	evt_bus.fire_event(other_evt);
+	evt_bus.remove_handler(other_event_reg);
 	std::cout << "Firing other event\n";
-	event_bus::fire_event(other_evt);
-	event_bus::fire_event(third_event{});
+	evt_bus.fire_event(other_evt);
+	evt_bus.fire_event(third_event{});
 	
 	std::cout << "callback count: " << callback_obj.get_event_count() << std::endl;
     return 0;

--- a/eventbus/CMakeLists.txt
+++ b/eventbus/CMakeLists.txt
@@ -25,12 +25,18 @@ if(EVENTBUS_BUILD_TESTS)
         test/main.cpp
         test/event_bus_tests.cpp
     )
-
-    add_executable(${PROJECT_NAME}.tests ${project_test_sources})
-    target_link_libraries(${PROJECT_NAME}.tests
+    set(project_test_name ${PROJECT_NAME}.tests)
+    add_executable(${project_test_name} ${project_test_sources})
+    target_link_libraries(${project_test_name}
         PUBLIC
             gtest
             gmock
             ${PROJECT_NAME}
+    )
+
+    include(GoogleTest)
+    gtest_add_tests(
+        TARGET ${project_test_name}
+        SOURCES ${project_test_sources}
     )
 endif()

--- a/eventbus/test/event_bus_tests.cpp
+++ b/eventbus/test/event_bus_tests.cpp
@@ -24,7 +24,6 @@ public:
 	[[nodiscard]] unsigned int get_count() const { return event_count_.load(); };
 	void on_test_event()
 	{
-		std::cout << "Handler counter.\n";
 		++event_count_;
 	}
 };
@@ -34,15 +33,15 @@ class EventBusTestFixture : public ::testing::Test
 protected:
 	event_handler_counter counter;
 	dp::handler_registration counter_event_registration_;
-	
+	dp::event_bus evt_bus;
 	void SetUp() override
 	{
-		counter_event_registration_ = dp::event_bus::register_handler<test_event_type>(&counter, &event_handler_counter::on_test_event);
+		counter_event_registration_ = evt_bus.register_handler<test_event_type>(&counter, &event_handler_counter::on_test_event);
 	}
 
 	void TearDown() override
 	{
-		dp::event_bus::remove_handler(counter_event_registration_);
+		evt_bus.remove_handler(counter_event_registration_);
 	}
 };
 
@@ -54,41 +53,120 @@ void free_function_callback(const test_event_type &type_event)
 TEST_F(EventBusTestFixture, LambdaRegistrationAndDeregistration)
 {
 	test_event_type test_event{ 1, "event message", 32.56 };
-	const auto lambda_one_reg = dp::event_bus::register_handler<test_event_type>([]() {std::cout << "Lambda 1\n"; });
-	const auto lambda_two_reg = dp::event_bus::register_handler<test_event_type>([&test_event](const test_event_type& evt)
+	const auto lambda_one_reg = evt_bus.register_handler<test_event_type>([]() {std::cout << "Lambda 1\n"; });
+	const auto lambda_two_reg = evt_bus.register_handler<test_event_type>([&test_event](const test_event_type& evt)
 		{
 			EXPECT_EQ(evt.id, test_event.id);
 			EXPECT_EQ(evt.event_message, test_event.event_message);
 			EXPECT_EQ(evt.data_value, test_event.data_value);
 		});
 
-	const auto lambda_three_reg = dp::event_bus::register_handler<test_event_type>([](test_event_type)
+	const auto lambda_three_reg = evt_bus.register_handler<test_event_type>([](test_event_type)
 		{
 			std::cout << "Lambda 3 take by copy.\n";
 		});
 
 	// should be 4 because we register a handler in the test fixture SetUp
-	ASSERT_EQ(dp::event_bus::handler_count(), 4);
-	dp::event_bus::fire_event(test_event);
+	ASSERT_EQ(evt_bus.handler_count(), 4);
+	evt_bus.fire_event(test_event);
 	EXPECT_EQ(counter.get_count(), 1);
-	dp::event_bus::fire_event(test_event);
+	evt_bus.fire_event(test_event);
 	EXPECT_EQ(counter.get_count(), 2);
 
-	dp::event_bus::remove_handler(lambda_one_reg);
+	evt_bus.remove_handler(lambda_one_reg);
 
-	dp::event_bus::fire_event(test_event);
+	evt_bus.fire_event(test_event);
 	EXPECT_EQ(counter.get_count(), 3);
-	EXPECT_EQ(dp::event_bus::handler_count(), 3);
+	EXPECT_EQ(evt_bus.handler_count(), 3);
 
-	dp::event_bus::remove_handler(lambda_two_reg);
+	evt_bus.remove_handler(lambda_two_reg);
 
-	dp::event_bus::fire_event(test_event);
+	evt_bus.fire_event(test_event);
 	EXPECT_EQ(counter.get_count(), 4);
-	EXPECT_EQ(dp::event_bus::handler_count(), 2);
+	EXPECT_EQ(evt_bus.handler_count(), 2);
 
-	dp::event_bus::remove_handler(lambda_three_reg);
+	evt_bus.remove_handler(lambda_three_reg);
 
-	dp::event_bus::fire_event(test_event);
+	evt_bus.fire_event(test_event);
 	EXPECT_EQ(counter.get_count(), 5);
-	EXPECT_EQ(dp::event_bus::handler_count(), 1);
+	EXPECT_EQ(evt_bus.handler_count(), 1);
+}
+
+TEST_F(EventBusTestFixture, RegisterWhileDispatching) 
+{
+	struct nefarious_event_listener 
+	{
+		dp::event_bus* evt_bus;
+		void on_event(test_event_type evt) 
+		{
+			nefarious_event_listener listener;
+			listener.evt_bus = evt_bus;
+			if(evt_bus) 
+			{
+				evt_bus->register_handler<test_event_type>(&listener, &nefarious_event_listener::on_event);
+			}
+		}
+	};
+
+	dp::handler_registration registration;
+	{
+		nefarious_event_listener listener;
+		listener.evt_bus = &evt_bus;
+		registration = evt_bus.register_handler<test_event_type>(&listener, &nefarious_event_listener::on_event);
+	}
+
+	for(auto i = 0; i < 40; ++i) {
+		evt_bus.fire_event(test_event_type{2, "test event", 1.3});
+		std::cout << "Handler count: " << evt_bus.handler_count() << "\n";
+		// count should be 2 because we registered the first nefarious object and the 
+		// test fixture class is registered as well (the counter).
+		ASSERT_EQ(evt_bus.handler_count(), 2);
+	}
+
+	ASSERT_TRUE(evt_bus.remove_handler(registration));
+}
+
+TEST_F(EventBusTestFixture, DeregisterWhileDispatching)
+{
+
+	struct deregister_while_dispatch_listener {
+		dp::event_bus *evt_bus{nullptr};
+		std::vector<dp::handler_registration> *registrations{nullptr};
+		void on_event(test_event_type)
+		{
+			if(evt_bus && registrations) {
+				std::for_each(registrations->begin(), registrations->end(), [&](auto reg) {
+					evt_bus->remove_handler(reg);
+				});
+			}
+		}
+	};
+
+	std::vector<dp::handler_registration> registrations;
+	std::vector<deregister_while_dispatch_listener> listeners;
+	for(auto i = 0; i < 20; ++i) {
+		deregister_while_dispatch_listener listener;
+		auto reg = evt_bus.register_handler<test_event_type>(&listener, &deregister_while_dispatch_listener::on_event);
+		listeners.emplace_back(listener);
+		registrations.emplace_back(reg);
+	}
+	
+	listeners[0].evt_bus = &evt_bus;
+	listeners[0].registrations = &registrations;
+
+	for(auto i = 0; i < 40; ++i) {
+		evt_bus.fire_event(test_event_type{3, "test event", 3.4});
+		std::cout << "Handler count: " << evt_bus.handler_count() << "\n";
+		// add 1 because of the test fixture.
+		EXPECT_EQ(evt_bus.handler_count(), listeners.size() + 1);
+	}
+
+	// remove all the registrations
+	for(auto reg: registrations) {
+		EXPECT_TRUE(evt_bus.remove_handler(reg));
+	}
+
+	EXPECT_EQ(evt_bus.handler_count(), 1);
+}
+
 }


### PR DESCRIPTION
## Changed

- Removed singleton class implementation
- Revised unit tests to address changes to class

## Fixed

- Add lock based access to the registration map so that listeners that try to register/de-register during event dispatch do not cause issues (#6)
- Make unit tests runnable via `ctest`