### PR TITLE
Add explicit system_error include

### DIFF
--- a/eventbus/include/eventbus/event_bus.hpp
+++ b/eventbus/include/eventbus/event_bus.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <mutex>
 #include <shared_mutex>
+#include <system_error>
 #include <thread>
 #include <typeindex>
 #include <unordered_map>


### PR DESCRIPTION
With gcc 14 I got this error:
```
error: ‘system_error’ in namespace ‘std’ does not name a type
```
I think with gcc 14 the implicit include dosn't work anymore.