### PR TITLE
Fix #38

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -25,7 +25,7 @@ class first_event_callback_object {
   public:
     first_event_callback_object() = default;
     void on_event_fired(const first_event&) { event_count_++; }
-    void on_third_event(){};
+    void on_third_event() {};
     [[nodiscard]] int get_event_count() const { return event_count_; }
 
   private:
@@ -34,7 +34,7 @@ class first_event_callback_object {
 
 class third_event_callback_object {
   public:
-    void on_third_event(){};
+    void on_third_event() {};
 };
 
 class internal_registration_class {
@@ -42,7 +42,7 @@ class internal_registration_class {
 
   public:
     internal_registration_class(dp::event_bus& bus)
-        : reg(std::move(bus.register_handler<first_event>([](const first_event& evt) {
+        : reg(std::move(bus.register_handler([](const first_event& evt) {
               std::cout << "test class: " << evt.message << "\n";
           }))) {}
 };
@@ -52,8 +52,8 @@ int main() {
     event_bus evt_bus;
 
     // register free function
-    const auto reg = evt_bus.register_handler<first_event>(&free_function_event_handler);
-    const auto third_event_reg = evt_bus.register_handler<third_event>([](const third_event& evt) {
+    const auto reg = evt_bus.register_handler(&free_function_event_handler);
+    const auto third_event_reg = evt_bus.register_handler([](const third_event& evt) {
         std::cout << "my third event handler: " << evt.value << new_line;
     });
 
@@ -68,23 +68,20 @@ int main() {
     evt_bus.remove_handler(third_event_reg);
     evt_bus.fire_event(third_event{13.0});
 
-    const auto other_event_reg =
-        evt_bus.register_handler<second_event>([](const second_event& other_evt) {
-            std::cout << "first other event handler says: " << other_evt.message << std::endl;
-        });
-    const auto other_event_second_reg =
-        evt_bus.register_handler<second_event>([](const second_event& other_evt) {
-            std::cout << "second other event handler says: " << other_evt.id << " "
-                      << other_evt.message << std::endl;
-        });
-    const auto dmy_evt_first_reg =
-        evt_bus.register_handler<first_event>([](const first_event& dmy_evt) {
-            std::cout << "third event handler says: " << dmy_evt.message << std::endl;
-        });
+    const auto other_event_reg = evt_bus.register_handler([](const second_event& other_evt) {
+        std::cout << "first other event handler says: " << other_evt.message << std::endl;
+    });
+    const auto other_event_second_reg = evt_bus.register_handler([](const second_event& other_evt) {
+        std::cout << "second other event handler says: " << other_evt.id << " " << other_evt.message
+                  << std::endl;
+    });
+    const auto dmy_evt_first_reg = evt_bus.register_handler([](const first_event& dmy_evt) {
+        std::cout << "third event handler says: " << dmy_evt.message << std::endl;
+    });
 
     first_event_callback_object callback_obj;
-    const auto dmy_evt_pmr_reg = evt_bus.register_handler<first_event>(
-        &callback_obj, &first_event_callback_object::on_event_fired);
+    const auto dmy_evt_pmr_reg =
+        evt_bus.register_handler(&callback_obj, &first_event_callback_object::on_event_fired);
     const auto thrid_event_reg_pmr = evt_bus.register_handler<third_event>(
         &callback_obj, &first_event_callback_object::on_third_event);
 

--- a/eventbus/include/eventbus/event_bus.hpp
+++ b/eventbus/include/eventbus/event_bus.hpp
@@ -32,12 +32,12 @@ namespace dp {
         handler_registration(handler_registration&& other) noexcept;
         handler_registration& operator=(const handler_registration& other) = delete;
         handler_registration& operator=(handler_registration&& other) noexcept;
-        ~handler_registration();
+        ~handler_registration() noexcept;
 
         /**
          * @brief Pointer to the underlying handle.
          */
-        [[nodiscard]] const void* handle() const;
+        [[nodiscard]] const void* handle() const noexcept;
 
         /**
          * @brief Unregister this handler from the event bus.
@@ -45,7 +45,7 @@ namespace dp {
         void unregister() noexcept;
 
       protected:
-        handler_registration(const void* handle, dp::event_bus* bus);
+        handler_registration(const void* handle, dp::event_bus* bus) noexcept;
         friend class event_bus;
     };
 
@@ -54,43 +54,37 @@ namespace dp {
      */
     class event_bus {
       public:
-        event_bus() = default;
+        /**
+         * @brief Register an event handler for a given event type.
+         * @tparam EventHandler The invocable event handler type.
+         * @param handler A callable handler of the event type. This invocation is designed for when
+         * `handler` takes the EventType as an argument.
+         * @return A handler_registration instance for the given handler.
+         */
+        template <typename EventHandler>
+        [[nodiscard]] auto register_handler(EventHandler&& handler) noexcept {
+            using EventType = typename detail::function_traits<EventHandler>::template arg<0>::type;
+
+            static_assert(std::is_invocable_v<EventHandler, EventType>,
+                          "EventHandler must be invocable with EventType as an argument.");
+
+            return register_handler_impl<EventType>(std::forward<EventHandler>(handler));
+        }
 
         /**
          * @brief Register an event handler for a given event type.
          * @tparam EventType The event type
          * @tparam EventHandler The invocable event handler type.
-         * @param handler A callable handler of the event type. Can accept the event as param or
-         * take no params.
+         * @param handler A callable handler of the event type. This invocation is used for when
+         * `handler` takes no parameters but wants to be fired when EventType is fired.
          * @return A handler_registration instance for the given handler.
          */
-        template <typename EventType, typename EventHandler,
-                  typename = std::enable_if_t<std::is_invocable_v<EventHandler> ||
-                                              std::is_invocable_v<EventHandler, EventType>>>
-        [[nodiscard]] handler_registration register_handler(EventHandler&& handler) {
-            using traits = detail::function_traits<EventHandler>;
-            const auto type_idx = std::type_index(typeid(EventType));
-            const void* handle;
-            // check if the function takes any arguments.
-            if constexpr (traits::arity == 0) {
-                safe_unique_registrations_access([&]() {
-                    auto it = handler_registrations_.emplace(
-                        type_idx,
-                        [handler = std::forward<EventHandler>(handler)](auto) { handler(); });
+        template <typename EventType, typename EventHandler>
+        [[nodiscard]] handler_registration register_handler(EventHandler&& handler) noexcept {
+            static_assert(std::is_invocable_v<EventHandler>,
+                          "EventHandler must be invocable with no arguments.");
 
-                    handle = static_cast<const void*>(&(it->second));
-                });
-            } else {
-                safe_unique_registrations_access([&]() {
-                    auto it = handler_registrations_.emplace(
-                        type_idx, [func = std::forward<EventHandler>(handler)](auto value) {
-                            func(std::any_cast<EventType>(value));
-                        });
-
-                    handle = static_cast<const void*>(&(it->second));
-                });
-            }
-            return {handle, this};
+            return register_handler_impl<EventType>(std::forward<EventHandler>(handler));
         }
 
         /**
@@ -99,38 +93,46 @@ namespace dp {
          * @tparam ClassType Event handler class
          * @tparam MemberFunction Event handler member function
          * @param class_instance Instance of ClassType that will handle the event.
-         * @param function Pointer to the MemberFunction of the ClassType.
+         * @param function Pointer to the MemberFunction of the ClassType. This invocation is for
+         * when `function` takes the EventType as an argument.
+         * @return A handler_registration instance for the given handler.
+         */
+        template <typename ClassType, typename MemberFunction>
+        [[nodiscard]] handler_registration register_handler(ClassType* class_instance,
+                                                            MemberFunction&& function) noexcept {
+            using EventType =
+                typename detail::function_traits<MemberFunction>::template arg<0>::type;
+
+            static_assert(
+                std::is_invocable_v<MemberFunction, ClassType*, EventType>,
+                "EventHandler must be a member function of ClassType and one EventType argument.");
+
+            return register_handler_impl<EventType>(
+                [class_instance, func = std::forward<MemberFunction>(function)](
+                    const EventType& event) { (class_instance->*func)(event); });
+        }
+
+        /**
+         * @brief Register an event handler for a given event type.
+         * @tparam EventType The event type
+         * @tparam ClassType Event handler class
+         * @tparam MemberFunction Event handler member function
+         * @param class_instance Instance of ClassType that will handle the event.
+         * @param function Pointer to the MemberFunction of the ClassType. This invocation is for
+         * when `function` takes no arguments but wants to be fired when EventType is fired.
          * @return A handler_registration instance for the given handler.
          */
         template <typename EventType, typename ClassType, typename MemberFunction>
         [[nodiscard]] handler_registration register_handler(ClassType* class_instance,
                                                             MemberFunction&& function) noexcept {
-            using traits = detail::function_traits<MemberFunction>;
-            static_assert(std::is_same_v<ClassType, std::decay_t<typename traits::owner_type>>,
-                          "Member function pointer must match instance type.");
+            static_assert(
+                std::is_invocable_v<MemberFunction, ClassType*>,
+                "EventHandler must be a member function of ClassType and take no arguments.");
 
-            const auto type_idx = std::type_index(typeid(EventType));
-            const void* handle;
-
-            if constexpr (traits::arity == 0) {
-                safe_unique_registrations_access([&]() {
-                    auto it = handler_registrations_.emplace(
-                        type_idx,
-                        [class_instance, function](auto) { (class_instance->*function)(); });
-
-                    handle = static_cast<const void*>(&(it->second));
+            return register_handler_impl<EventType>(
+                [class_instance, func = std::forward<MemberFunction>(function)]() {
+                    (class_instance->*func)();
                 });
-            } else {
-                safe_unique_registrations_access([&]() {
-                    auto it = handler_registrations_.emplace(
-                        type_idx, [class_instance, function](auto value) {
-                            (class_instance->*function)(std::any_cast<EventType>(value));
-                        });
-
-                    handle = static_cast<const void*>(&(it->second));
-                });
-            }
-            return {handle, this};
         }
 
         /**
@@ -139,13 +141,14 @@ namespace dp {
          * @param evt The event to pass to all event handlers.
          */
         template <typename EventType, typename = std::enable_if_t<!std::is_pointer_v<EventType>>>
-        void fire_event(EventType&& evt) noexcept {
-            safe_shared_registrations_access([this, local_event = std::forward<EventType>(evt)]() {
+        void fire_event(const EventType& evt) noexcept {
+            safe_shared_registrations_access([this, &evt]() {
                 // only call the functions we need to
                 for (auto [begin_evt_id, end_evt_id] =
                          handler_registrations_.equal_range(std::type_index(typeid(EventType)));
                      begin_evt_id != end_evt_id; ++begin_evt_id) {
-                    begin_evt_id->second(local_event);
+                    // call all handlers by passing a std::reference_wrapper<const EventType>
+                    begin_evt_id->second(std::cref(evt));
                 }
             });
         }
@@ -199,26 +202,70 @@ namespace dp {
             handler_registrations_;
 
         template <typename Callable>
-        void safe_shared_registrations_access(Callable&& callable) {
+        void safe_shared_registrations_access(Callable&& callable) noexcept {
             try {
-                std::shared_lock<mutex_type> lock(registration_mutex_);
+                std::scoped_lock lock{registration_mutex_};
                 callable();
             } catch (std::system_error&) {
             }
         }
+
         template <typename Callable>
-        void safe_unique_registrations_access(Callable&& callable) {
+        void safe_unique_registrations_access(Callable&& callable) noexcept {
             try {
                 // if this fails, an exception may be thrown.
-                std::unique_lock<mutex_type> lock(registration_mutex_);
+                std::scoped_lock lock{registration_mutex_};
                 callable();
             } catch (std::system_error&) {
                 // do nothing
             }
         }
+
+        // Helper function which drastically cleans up the template parameterization requirements of
+        // the users of this library. EventType is now deduced from the handler function directly
+        // unless it takes no arguments.
+        template <typename EventType, typename EventHandler>
+        [[nodiscard]] handler_registration register_handler_impl(EventHandler&& handler) noexcept {
+            using traits = detail::function_traits<EventHandler>;
+            using RawParameterType = std::remove_cv_t<std::remove_reference_t<EventType>>;
+
+            const auto type_idx = std::type_index(typeid(RawParameterType));
+            const void* handle;
+
+            // check if the function takes any arguments.
+            if constexpr (traits::arity == 0) {
+                safe_unique_registrations_access([&]() {
+                    auto it = handler_registrations_.emplace(
+                        type_idx,
+                        [func = std::forward<EventHandler>(handler)](std::any&&) { func(); });
+
+                    handle = static_cast<const void*>(&(it->second));
+                });
+            } else {
+                safe_unique_registrations_access([&]() {
+                    auto it = handler_registrations_.emplace(
+                        type_idx, [func = std::forward<EventHandler>(handler)](std::any&& value) {
+                            std::reference_wrapper<const RawParameterType> local_event =
+                                std::any_cast<std::reference_wrapper<const RawParameterType>>(
+                                    std::move(value));
+
+                            if constexpr (std::is_rvalue_reference_v<EventType>) {
+                                static_assert(std::is_copy_constructible_v<RawParameterType>,
+                                              "Event type must be copy constructible.");
+                                func(RawParameterType(local_event.get()));
+                            } else {
+                                func(local_event);
+                            }
+                        });
+
+                    handle = static_cast<const void*>(&(it->second));
+                });
+            }
+            return {handle, this};
+        }
     };
 
-    inline const void* handler_registration::handle() const { return handle_; }
+    inline const void* handler_registration::handle() const noexcept { return handle_; }
 
     inline void handler_registration::unregister() noexcept {
         if (event_bus_ && handle_) {
@@ -227,7 +274,8 @@ namespace dp {
         }
     }
 
-    inline handler_registration::handler_registration(const void* handle, dp::event_bus* bus)
+    inline handler_registration::handler_registration(const void* handle,
+                                                      dp::event_bus* bus) noexcept
         : handle_(handle), event_bus_(bus) {}
 
     inline handler_registration::handler_registration(handler_registration&& other) noexcept
@@ -241,5 +289,5 @@ namespace dp {
         return *this;
     }
 
-    inline handler_registration::~handler_registration() { unregister(); }
+    inline handler_registration::~handler_registration() noexcept { unregister(); }
 }  // namespace dp

--- a/eventbus/test/event_bus_tests.cpp
+++ b/eventbus/test/event_bus_tests.cpp
@@ -1,10 +1,10 @@
 #include <doctest/doctest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <eventbus/event_bus.hpp>
 #include <iostream>
 #include <thread>
-#include <algorithm>
 
 struct test_event_type {
     int id{-1};
@@ -39,15 +39,14 @@ TEST_CASE("lambda registration and de-registration") {
     test_event_type test_event{1, "event message", 32.56};
     const auto lambda_one_reg =
         evt_bus.register_handler<test_event_type>([]() { std::cout << "Lambda 1\n"; });
-    const auto lambda_two_reg =
-        evt_bus.register_handler<test_event_type>([&test_event](const test_event_type& evt) {
-            CHECK_EQ(evt.id, test_event.id);
-            CHECK_EQ(evt.event_message, test_event.event_message);
-            CHECK_EQ(evt.data_value, test_event.data_value);
-        });
+    const auto lambda_two_reg = evt_bus.register_handler([&test_event](const test_event_type& evt) {
+        CHECK_EQ(evt.id, test_event.id);
+        CHECK_EQ(evt.event_message, test_event.event_message);
+        CHECK_EQ(evt.data_value, test_event.data_value);
+    });
 
-    const auto lambda_three_reg = evt_bus.register_handler<test_event_type>(
-        [](test_event_type) { std::cout << "Lambda 3 take by copy.\n"; });
+    const auto lambda_three_reg =
+        evt_bus.register_handler([](test_event_type) { std::cout << "Lambda 3 take by copy.\n"; });
 
     // should be 4 because we register a handler in the test fixture SetUp
     REQUIRE_EQ(evt_bus.handler_count(), 4);
@@ -96,8 +95,8 @@ TEST_CASE("deregister while dispatching") {
     std::vector<deregister_while_dispatch_listener> listeners;
     for (auto i = 0; i < 20; ++i) {
         deregister_while_dispatch_listener listener;
-        auto reg = evt_bus.register_handler<test_event_type>(
-            &listener, &deregister_while_dispatch_listener::on_event);
+        auto reg =
+            evt_bus.register_handler(&listener, &deregister_while_dispatch_listener::on_event);
         listeners.emplace_back(listener);
         registrations.emplace_back(std::move(reg));
     }
@@ -135,10 +134,8 @@ TEST_CASE("multi-threaded event dispatch") {
     simple_listener listener_one(1);
     simple_listener listener_two(2);
 
-    auto reg_one =
-        evt_bus.register_handler<test_event_type>(&listener_one, &simple_listener::on_event);
-    auto reg_two =
-        evt_bus.register_handler<test_event_type>(&listener_two, &simple_listener::on_event);
+    auto reg_one = evt_bus.register_handler(&listener_one, &simple_listener::on_event);
+    auto reg_two = evt_bus.register_handler(&listener_two, &simple_listener::on_event);
 
     event_handler_counter event_counter;
     auto event_handler_reg = evt_bus.register_handler<test_event_type>(
@@ -178,4 +175,58 @@ TEST_CASE("auto de-register in destructor") {
     evt_bus.fire_event(test_event_type{});
     evt_bus.fire_event(test_event_type{});
     CHECK_EQ(counter.get_count(), 0);
+}
+
+TEST_CASE("Ensure events are not unnecessarily copied") {
+    dp::event_bus evt_bus;
+    bool event_copied = false;
+
+    struct event_checker {
+        bool& event_copied;
+
+        event_checker& operator=(const event_checker&) {
+            event_copied = true;
+            return *this;
+        }
+        event_checker(const event_checker& other) : event_copied{other.event_copied} {
+            event_copied = true;
+        }
+        event_checker(bool& copied) : event_copied{copied} {}
+    };
+
+    event_checker checker{event_copied};
+
+    auto registration1 = evt_bus.register_handler([](const event_checker& evt) {});
+
+    auto registration2 = evt_bus.register_handler([](const event_checker& evt) {});
+
+    // l-value reference
+    evt_bus.fire_event(checker);
+    // r-value reference
+    evt_bus.fire_event(event_checker{event_copied});
+    CHECK_FALSE(event_copied);
+
+    {
+        // register a handler that expects a value type -- this will make a copy
+        auto registration3 = evt_bus.register_handler([](event_checker evt) {});
+
+        evt_bus.fire_event(checker);
+        CHECK(event_copied);
+
+        // register a handler that expects an r-value reference -- this will make a copy
+        auto registration4 = evt_bus.register_handler([](event_checker&& evt) {});
+        event_copied = false;
+
+        evt_bus.fire_event(checker);
+        CHECK(event_copied);
+    }
+    // deregister copying events
+
+    event_copied = false;
+
+    const event_checker const_checker{event_copied};
+
+    evt_bus.fire_event(const_checker);
+
+    CHECK_FALSE(event_copied);
 }


### PR DESCRIPTION
Implemented a fix for #38 such that if an event handler expects a reference to the event, it is given one without making a copy. 

R-value references and value type parameters are handed copies. 

This is also technically a breaking change, as EventTypes are now inferred by the event handler function traits, which will break current implementations but for the better. 