### PR TITLE
Unified `eventbus` impl for any and variant storage types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ if(EVENTBUS_BUILD_TESTS)
     CPMAddPackage(
         NAME doctest
         GITHUB_REPOSITORY onqtam/doctest
+        # bump CMake version to 3.5
+        GIT_TAG 3a01ec37828affe4c9650004edb5b304fb9d5b75
         VERSION 2.4.11
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.25)
 
 project(eventbus)
 
@@ -7,7 +7,10 @@ set(CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(CPM)
+
 option(EVENTBUS_BUILD_TESTS "Build unit tests." ON)
+option(EVENTBUS_BUILD_BENCHMARKS "Build benchmarks." OFF)
+option(EVENTBUS_BUILD_EXAMPLES "Build examples" OFF)
 
 # set up warnings interface project to re-use
 include(CompilerWarnings)
@@ -33,4 +36,11 @@ if(EVENTBUS_BUILD_TESTS)
 endif()
 
 add_subdirectory(eventbus)
-add_subdirectory(demo)
+
+if(EVENTBUS_BUILD_EXAMPLES)
+    add_subdirectory(demo)
+endif()
+
+if(EVENTBUS_BUILD_BENCHMARKS)
+    add_subdirectory(benchmark)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,201 +1,198 @@
 ﻿{
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "base",
-            "hidden": true,
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
-                "EVENTBUS_BUILD_TESTS": "ON"
-            }
-        },
-        {
-            "name": "macos-base",
-            "hidden": true,
-            "inherits": "base",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Darwin"
-            }
-        },
-        {
-            "name": "clang-debug",
-            "inherits": "macos-base",
-            "displayName": "macOS Clang Debug",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_C_COMPILER": "clang"
-            }
-        },
-        {
-            "name": "clang-release",
-            "inherits": "macos-base",
-            "displayName": "macOS Clang Release",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_C_COMPILER": "clang"
-            }
-        },
-        {
-            "name": "linux-base",
-            "hidden": true,
-            "description": "Target the Windows Subsystem for Linux (WSL) or a remote Linux system.",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
-                    "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
-                }
-            },
-            "cacheVariables": {
-                "EVENTBUS_BUILD_TESTS": "ON"
-            }
-        },
-        {
-            "name": "windows-base",
-            "description": "Target Windows with the Visual Studio development environment.",
-            "hidden": true,
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}",
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_C_COMPILER": "cl"
-            },
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "architecture": {
-                "value": "x64",
-                "strategy": "external"
-            },
-            "toolset": {
-                "value": "host=x64",
-                "strategy": "external"
-            }
-        },
-        {
-            "name": "gcc-base",
-            "hidden": true,
-            "inherits": "linux-base",
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_C_COMPILER": "gcc"
-            }
-        },
-        {
-            "name": "gcc-debug",
-            "inherits": "gcc-base",
-            "displayName": "GCC Debug",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "gcc-release",
-            "inherits": "gcc-base",
-            "displayName": "GCC Release",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
-            "name": "clang-base",
-            "hidden": true,
-            "inherits": "linux-base",
-            "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_C_COMPILER": "clang"
-            }
-        },
-        {
-            "name": "clang-debug",
-            "inherits": "clang-base",
-            "displayName": "Clang Debug",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "clang-release",
-            "inherits": "clang-base",
-            "displayName": "Clang Release",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
-            "name": "clang-release-with-debug-info",
-            "inherits": "clang-base",
-            "displayName": "Clang RelWithDebInfo",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "x64-debug",
-            "displayName": "x64 Debug",
-            "description": "Target Windows (64-bit) with the Visual Studio development environment. (Debug)",
-            "inherits": "windows-base",
-            "architecture": {
-                "value": "x64",
-                "strategy": "external"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "x64-debug-clang",
-            "displayName": "x64 Debug Clang",
-            "description": "Target Windows (64-bit) with Clang",
-            "inherits": "windows-base",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "x64-release-clang",
-            "displayName": "x64 Release Clang",
-            "description": "Target Windows (64-bit) with Clang (Release)",
-            "inherits": "windows-base",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
-            "name": "x64-release",
-            "displayName": "x64 Release",
-            "description": "Target Windows (64-bit) with the Visual Studio development environment. (Release)",
-            "inherits": "x64-debug",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
-            "name": "x64-release-with-debug",
-            "displayName": "x64 Release w/Debug",
-            "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
-            "inherits": "x64-debug",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/build/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
+        "EVENTBUS_BUILD_TESTS": "ON",
+        "EVENTBUS_BUILD_EXAMPLES": "ON",
+        "EVENTBUS_BUILD_BENCHMARKS": "ON"
+      }
+    },
+    {
+      "name": "macos-base",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "clang-debug",
+      "inherits": "macos-base",
+      "displayName": "macOS Clang Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_COMPILER": "clang"
+      }
+    },
+    {
+      "name": "clang-release",
+      "inherits": "macos-base",
+      "displayName": "macOS Clang Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_COMPILER": "clang"
+      }
+    },
+    {
+      "name": "linux-base",
+      "hidden": true,
+      "inherits": "base",
+      "description": "Target the Windows Subsystem for Linux (WSL) or a remote Linux system.",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
+          "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
         }
-    ]
+      }
+    },
+    {
+      "name": "windows-base",
+      "description": "Target Windows with the Visual Studio development environment.",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_C_COMPILER": "cl"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "gcc-base",
+      "hidden": true,
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_C_COMPILER": "gcc"
+      }
+    },
+    {
+      "name": "gcc-debug",
+      "inherits": "gcc-base",
+      "displayName": "GCC Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "gcc-release",
+      "inherits": "gcc-base",
+      "displayName": "GCC Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "clang-base",
+      "hidden": true,
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_COMPILER": "clang"
+      }
+    },
+    {
+      "name": "clang-debug",
+      "inherits": "clang-base",
+      "displayName": "Clang Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "clang-release",
+      "inherits": "clang-base",
+      "displayName": "Clang Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "clang-release-with-debug-info",
+      "inherits": "clang-base",
+      "displayName": "Clang RelWithDebInfo",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "x64-debug",
+      "displayName": "x64 Debug",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (Debug)",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "x64-debug-clang",
+      "displayName": "x64 Debug Clang",
+      "description": "Target Windows (64-bit) with Clang",
+      "inherits": "windows-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "x64-release-clang",
+      "displayName": "x64 Release Clang",
+      "description": "Target Windows (64-bit) with Clang (Release)",
+      "inherits": "windows-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "x64-release",
+      "displayName": "x64 Release",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (Release)",
+      "inherits": "x64-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "x64-release-with-debug",
+      "displayName": "x64 Release w/Debug",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
+      "inherits": "x64-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    }
+  ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,6 +2,46 @@
     "version": 3,
     "configurePresets": [
         {
+            "name": "base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
+                "EVENTBUS_BUILD_TESTS": "ON"
+            }
+        },
+        {
+            "name": "macos-base",
+            "hidden": true,
+            "inherits": "base",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "clang-debug",
+            "inherits": "macos-base",
+            "displayName": "macOS Clang Debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_COMPILER": "clang"
+            }
+        },
+        {
+            "name": "clang-release",
+            "inherits": "macos-base",
+            "displayName": "macOS Clang Release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_COMPILER": "clang"
+            }
+        },
+        {
             "name": "linux-base",
             "hidden": true,
             "description": "Target the Windows Subsystem for Linux (WSL) or a remote Linux system.",

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.25)
+project(eventbus-benchmarks)
+
+CPMAddPackage(
+    NAME nanobench
+    GITHUB_REPOSITORY martinus/nanobench
+    VERSION 4.3.11
+    GIT_SHALLOW
+)
+
+file(GLOB benchmark_sources CONFIGURE_DEPENDS src/*.cpp)
+add_executable(${PROJECT_NAME} ${benchmark_sources})
+target_link_libraries(
+    ${PROJECT_NAME} 
+    PUBLIC 
+        dp::eventbus
+        doctest::doctest
+        nanobench
+        project_options
+        project_warnings
+)

--- a/benchmark/src/event_bus.cpp
+++ b/benchmark/src/event_bus.cpp
@@ -49,7 +49,7 @@ TEST_CASE("event dispatch - std::any vs std::variant") {
         });
 
         bench.run("std::variant", [dispatch_count]() {
-            auto bus = dp::make_event_bus_for_types<event, event2>();
+            dp::event_bus<event, event2> bus{};
 
             auto registration1 = bus.register_handler<event>([] {});
             auto registration2 = bus.register_handler<event2>([] {});
@@ -93,7 +93,7 @@ TEST_CASE("event dispatch - std::any vs std::variant with allocating event") {
         });
 
         bench.run("std::variant", [dispatch_count]() {
-            auto bus = dp::make_event_bus_for_types<allocating_event>();
+            dp::event_bus<allocating_event> bus{};
 
             auto registration1 = bus.register_handler<allocating_event>([] {});
             ankerl::nanobench::doNotOptimizeAway(registration1);

--- a/benchmark/src/event_bus.cpp
+++ b/benchmark/src/event_bus.cpp
@@ -1,0 +1,60 @@
+#include <doctest/doctest.h>
+#include <nanobench.h>
+
+#include <chrono>
+#include <eventbus/event_bus.hpp>
+#include <string>
+#include <vector>
+
+TEST_CASE("event dispatch - std::any vs std::variant") {
+    // This test compares the performance of event dispatching using std::any and std::variant
+    std::vector<std::size_t> args = {1'000, 10'000, 100'000, 1'000'000};
+
+    using namespace std::chrono_literals;
+    for (const auto& dispatch_count : args) {
+        ankerl::nanobench::Bench bench;
+        auto bench_title =
+            std::string("event dispatch - " + std::to_string(dispatch_count) + " times");
+        bench.title(bench_title).relative(true).warmup(100).minEpochIterations(1000);
+        bench.timeUnit(1us, "us");
+
+        struct event {
+            int data_int;
+            float data_float;
+            double data_double;
+            std::uint64_t data_int_large;
+        };
+
+        struct event2 {
+            int data_int;
+        };
+
+        bench.run("std::any", [dispatch_count]() {
+            dp::event_bus bus{};
+
+            auto registration1 = bus.register_handler<event>([] {});
+            auto registration2 = bus.register_handler<event2>([] {});
+            ankerl::nanobench::doNotOptimizeAway(registration1);
+            ankerl::nanobench::doNotOptimizeAway(registration2);
+
+            for (std::size_t i = 0; i < dispatch_count; ++i) {
+                bus.fire_event(event{});
+                bus.fire_event(event2{});
+            }
+        });
+
+        bench.run("std::variant", [dispatch_count]() {
+            auto bus = dp::make_event_bus_for_types<event, event2>();
+
+            auto registration1 = bus.register_handler<event>([] {});
+            auto registration2 = bus.register_handler<event2>([] {});
+            ankerl::nanobench::doNotOptimizeAway(registration1);
+            ankerl::nanobench::doNotOptimizeAway(registration2);
+
+            for (std::size_t i = 0; i < dispatch_count; ++i) {
+                bus.fire_event(event{});
+                bus.fire_event(event2{});
+            }
+        });
+    }
+}

--- a/benchmark/src/event_bus.cpp
+++ b/benchmark/src/event_bus.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("event dispatch - std::any vs std::variant") {
     // This test compares the performance of event dispatching using std::any and std::variant
-    std::vector<std::size_t> args = {1'000, 10'000, 100'000, 1'000'000};
+    std::vector<std::size_t> args = {1'000, 10'000, 100'000};
 
     using namespace std::chrono_literals;
     for (const auto& dispatch_count : args) {
@@ -27,6 +27,11 @@ TEST_CASE("event dispatch - std::any vs std::variant") {
 
         struct event2 {
             int data_int;
+        };
+
+        struct allocating_event {
+            std::vector<std::byte> data;
+            allocating_event() : data(8, std::byte{0}) {}  // 8 bytes
         };
 
         bench.run("std::any", [dispatch_count]() {
@@ -54,6 +59,47 @@ TEST_CASE("event dispatch - std::any vs std::variant") {
             for (std::size_t i = 0; i < dispatch_count; ++i) {
                 bus.fire_event(event{});
                 bus.fire_event(event2{});
+            }
+        });
+    }
+}
+
+TEST_CASE("event dispatch - std::any vs std::variant with allocating event") {
+    // This test compares the performance of event dispatching using std::any and std::variant
+    std::vector<std::size_t> args = {1'000, 10'000};
+
+    using namespace std::chrono_literals;
+    for (const auto& dispatch_count : args) {
+        ankerl::nanobench::Bench bench;
+        auto bench_title =
+            std::string("event dispatch - " + std::to_string(dispatch_count) + " times");
+        bench.title(bench_title).relative(true).warmup(100).minEpochIterations(1000);
+        bench.timeUnit(1us, "us");
+
+        struct allocating_event {
+            std::vector<std::byte> data;
+            allocating_event() : data(8, std::byte{0}) {}  // 8 bytes
+        };
+
+        bench.run("std::any", [dispatch_count]() {
+            dp::event_bus bus{};
+
+            auto registration1 = bus.register_handler<allocating_event>([] {});
+            ankerl::nanobench::doNotOptimizeAway(registration1);
+
+            for (std::size_t i = 0; i < dispatch_count; ++i) {
+                bus.fire_event(allocating_event{});
+            }
+        });
+
+        bench.run("std::variant", [dispatch_count]() {
+            auto bus = dp::make_event_bus_for_types<allocating_event>();
+
+            auto registration1 = bus.register_handler<allocating_event>([] {});
+            ankerl::nanobench::doNotOptimizeAway(registration1);
+
+            for (std::size_t i = 0; i < dispatch_count; ++i) {
+                bus.fire_event(allocating_event{});
             }
         });
     }

--- a/benchmark/src/main.cpp
+++ b/benchmark/src/main.cpp
@@ -1,0 +1,2 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -78,11 +78,15 @@ function(set_project_warnings project_name)
       -Wuseless-cast # warn if you perform a cast to the same type
   )
 
+  message("Using compiler: ${CMAKE_CXX_COMPILER_ID}")
   # clang can be used with visual studio directly and uses the cl like interface.
   if(MSVC AND NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     set(PROJECT_WARNINGS ${CLANG_WARNINGS})
+  elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+    list(REMOVE_ITEM ${CLANG_WARNINGS} -Wduplicated-cond)
+    set(PROJECT_WARNINGS ${CLANG_WARNINGS}) # AppleClang doesn't support -Wpedantic
   else()
     set(PROJECT_WARNINGS ${GCC_WARNINGS})
   endif()

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -41,7 +41,8 @@ class internal_registration_class {
     dp::handler_registration reg;
 
   public:
-    internal_registration_class(dp::event_bus& bus)
+    /// CTAD not allowed in non-static struct member so we have to include the empty brackets
+    internal_registration_class(dp::event_bus<>& bus)
         : reg(std::move(bus.register_handler([](const first_event& evt) {
               std::cout << "test class: " << evt.message << "\n";
           }))) {}

--- a/eventbus/CMakeLists.txt
+++ b/eventbus/CMakeLists.txt
@@ -4,6 +4,8 @@ project(eventbus)
 
 set(project_headers
     include/eventbus/detail/function_traits.hpp
+    include/eventbus/detail/storage_policy.hpp
+    include/eventbus/detail/value_traits.hpp
     include/eventbus/event_bus.hpp
 )
 

--- a/eventbus/CMakeLists.txt
+++ b/eventbus/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(${PROJECT_NAME} INTERFACE project_options Threads::Threads
 
 if(EVENTBUS_BUILD_TESTS)
     file(GLOB_RECURSE project_test_sources CONFIGURE_DEPENDS test/*.cpp)
-    set(project_test_name ${PROJECT_NAME}.tests)
+    set(project_test_name ${PROJECT_NAME}-tests)
     add_executable(${project_test_name} ${project_test_sources})
     target_link_libraries(${project_test_name}
         PUBLIC

--- a/eventbus/include/eventbus/detail/storage_policy.hpp
+++ b/eventbus/include/eventbus/detail/storage_policy.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <any>
+#include <functional>
+#include <variant>
+
+namespace dp::detail {
+    struct any_event_bus_storage_policy {
+        using event_type = std::any;
+        using event_handler = std::function<void(event_type)>;
+    };
+
+    template <typename... EventTypes>
+    struct variant_event_bus_storage_policy {
+        using event_type = std::variant<EventTypes...>;
+        using event_handler = std::function<void(event_type)>;
+    };
+}  // namespace dp::detail

--- a/eventbus/include/eventbus/detail/storage_policy.hpp
+++ b/eventbus/include/eventbus/detail/storage_policy.hpp
@@ -12,7 +12,7 @@ namespace dp::detail {
 
     template <typename... EventTypes>
     struct variant_event_bus_storage_policy {
-        using event_type = std::variant<EventTypes...>;
+        using event_type = std::variant<std::reference_wrapper<const EventTypes>...>;
         using event_handler = std::function<void(event_type)>;
     };
 }  // namespace dp::detail

--- a/eventbus/include/eventbus/detail/value_traits.hpp
+++ b/eventbus/include/eventbus/detail/value_traits.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <any>
+#include <type_traits>
+
+namespace dp::detail {
+    template <typename T>
+    struct is_any : std::false_type {};
+    template <>
+    struct is_any<std::any> : std::true_type {};
+
+}  // namespace dp::detail

--- a/eventbus/include/eventbus/event_bus.hpp
+++ b/eventbus/include/eventbus/event_bus.hpp
@@ -10,55 +10,90 @@
 #include <typeindex>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
-#include "detail/function_traits.hpp"
+#include "eventbus/detail/function_traits.hpp"
+#include "eventbus/detail/storage_policy.hpp"
+#include "eventbus/detail/value_traits.hpp"
 
+namespace {
+    template <typename Event, typename RawParameterType>
+    auto access_event_value(Event&& value) -> std::reference_wrapper<const RawParameterType> {
+        if constexpr (dp::detail::is_any<Event>::value) {
+            return std::any_cast<std::reference_wrapper<const RawParameterType>>(value);
+        } else {
+            return std::cref(std::get<RawParameterType>(value));
+        }
+    }
+}  // namespace
 namespace dp {
-    class event_bus;
-
-    /**
-     * @brief A registration handle for a particular handler of an event type.
-     * @details This class is move constructible only. It also assumed that the lifespan of this
-     * object will be as long or shorter than that of the event bus. This class is move
-     * constructible for that reason, but there are still some cases where you can run into life
-     * time issues.
-     */
-    class handler_registration {
-        const void* handle_{nullptr};
-        dp::event_bus* event_bus_{nullptr};
-
-      public:
-        handler_registration(const handler_registration& other) = delete;
-        handler_registration(handler_registration&& other) noexcept;
-        handler_registration& operator=(const handler_registration& other) = delete;
-        handler_registration& operator=(handler_registration&& other) noexcept;
-        ~handler_registration() noexcept;
-
-        /**
-         * @brief Pointer to the underlying handle.
-         */
-        [[nodiscard]] const void* handle() const noexcept;
-
-        /**
-         * @brief Unregister this handler from the event bus.
-         */
-        void unregister() noexcept;
-
-      protected:
-        handler_registration(const void* handle, dp::event_bus* bus) noexcept;
-        friend class event_bus;
-    };
+    struct default_event_bus_storage_policy : detail::any_event_bus_storage_policy {};
 
     /**
      * @brief A central event handler class that connects event handlers with the events.
      */
-    class event_bus {
+    template <typename StoragePolicy = default_event_bus_storage_policy>
+    class event_bus_impl {
       public:
+        /**
+         * @brief A registration handle for a particular handler of an event type.
+         * @details This class is move constructible only. It also assumed that the lifespan of this
+         * object will be as long or shorter than that of the event bus. This class is move
+         * constructible for that reason, but there are still some cases where you can run into life
+         * time issues.
+         */
+        class handler_registration {
+            const void* handle_{nullptr};
+            dp::event_bus_impl<StoragePolicy>* event_bus_{nullptr};
+
+          public:
+            handler_registration(handler_registration&& other) noexcept
+                : handle_(std::exchange(other.handle_, nullptr)),
+                  event_bus_(std::exchange(other.event_bus_, nullptr)) {}
+
+            handler_registration& operator=(handler_registration&& other) noexcept {
+                handle_ = std::exchange(other.handle_, nullptr);
+                event_bus_ = std::exchange(other.event_bus_, nullptr);
+                return *this;
+            }
+            ~handler_registration() noexcept { unregister(); }
+
+            handler_registration(const handler_registration& other) = delete;
+            handler_registration& operator=(const handler_registration& other) = delete;
+            /**
+             * @brief Pointer to the underlying handle.
+             */
+            [[nodiscard]] const void* handle() const noexcept { return handle_; }
+
+            /**
+             * @brief Unregister this handler from the event bus.
+             */
+            void unregister() noexcept {
+                if (event_bus_ && handle_) {
+                    event_bus_->remove_handler(*this);
+                    handle_ = nullptr;
+                }
+            }
+
+          protected:
+            handler_registration(const void* handle,
+                                 dp::event_bus_impl<StoragePolicy>* bus) noexcept
+                : handle_(handle), event_bus_(bus) {}
+            friend class event_bus_impl;
+        };
+
+        /// @brief Public type aliases
+        /// @{
+        using event_type = typename StoragePolicy::event_type;
+        using event_handler = typename StoragePolicy::event_handler;
+        using handler_registration = typename event_bus_impl::handler_registration;
+        /// @}
+
         /**
          * @brief Register an event handler for a given event type.
          * @tparam EventHandler The invocable event handler type.
-         * @param handler A callable handler of the event type. This invocation is designed for when
-         * `handler` takes the EventType as an argument.
+         * @param handler A callable handler of the event type. This invocation is designed for
+         * when `handler` takes the EventType as an argument.
          * @return A handler_registration instance for the given handler.
          */
         template <typename EventHandler>
@@ -93,8 +128,8 @@ namespace dp {
          * @tparam ClassType Event handler class
          * @tparam MemberFunction Event handler member function
          * @param class_instance Instance of ClassType that will handle the event.
-         * @param function Pointer to the MemberFunction of the ClassType. This invocation is for
-         * when `function` takes the EventType as an argument.
+         * @param function Pointer to the MemberFunction of the ClassType. This invocation is
+         * for when `function` takes the EventType as an argument.
          * @return A handler_registration instance for the given handler.
          */
         template <typename ClassType, typename MemberFunction>
@@ -103,9 +138,9 @@ namespace dp {
             using EventType =
                 typename detail::function_traits<MemberFunction>::template arg<0>::type;
 
-            static_assert(
-                std::is_invocable_v<MemberFunction, ClassType*, EventType>,
-                "EventHandler must be a member function of ClassType and one EventType argument.");
+            static_assert(std::is_invocable_v<MemberFunction, ClassType*, EventType>,
+                          "EventHandler must be a member function of ClassType and one "
+                          "EventType argument.");
 
             return register_handler_impl<EventType>(
                 [class_instance, func = std::forward<MemberFunction>(function)](
@@ -118,8 +153,8 @@ namespace dp {
          * @tparam ClassType Event handler class
          * @tparam MemberFunction Event handler member function
          * @param class_instance Instance of ClassType that will handle the event.
-         * @param function Pointer to the MemberFunction of the ClassType. This invocation is for
-         * when `function` takes no arguments but wants to be fired when EventType is fired.
+         * @param function Pointer to the MemberFunction of the ClassType. This invocation is
+         * for when `function` takes no arguments but wants to be fired when EventType is fired.
          * @return A handler_registration instance for the given handler.
          */
         template <typename EventType, typename ClassType, typename MemberFunction>
@@ -198,8 +233,7 @@ namespace dp {
       private:
         using mutex_type = std::shared_mutex;
         mutable mutex_type registration_mutex_;
-        std::unordered_multimap<std::type_index, std::function<void(std::any)>>
-            handler_registrations_;
+        std::unordered_multimap<std::type_index, event_handler> handler_registrations_;
 
         template <typename Callable>
         void safe_shared_registrations_access(Callable&& callable) noexcept {
@@ -221,9 +255,9 @@ namespace dp {
             }
         }
 
-        // Helper function which drastically cleans up the template parameterization requirements of
-        // the users of this library. EventType is now deduced from the handler function directly
-        // unless it takes no arguments.
+        // Helper function which drastically cleans up the template parameterization
+        // requirements of the users of this library. EventType is now deduced from the handler
+        // function directly unless it takes no arguments.
         template <typename EventType, typename EventHandler>
         [[nodiscard]] handler_registration register_handler_impl(EventHandler&& handler) noexcept {
             using traits = detail::function_traits<EventHandler>;
@@ -234,21 +268,25 @@ namespace dp {
 
             // check if the function takes any arguments.
             if constexpr (traits::arity == 0) {
+                // arity is 0, so we can safely call the function without any arguments.
                 safe_unique_registrations_access([&]() {
                     auto it = handler_registrations_.emplace(
                         type_idx,
-                        [func = std::forward<EventHandler>(handler)](std::any&&) { func(); });
+                        [func = std::forward<EventHandler>(handler)](event_type&&) { func(); });
 
                     handle = static_cast<const void*>(&(it->second));
                 });
             } else {
+                // function takes at least one argument, so we need to wrap the event in a
+                // std::reference_wrapper to avoid copying the event.
                 safe_unique_registrations_access([&]() {
                     auto it = handler_registrations_.emplace(
-                        type_idx, [func = std::forward<EventHandler>(handler)](std::any&& value) {
+                        type_idx, [func = std::forward<EventHandler>(handler)](event_type&& value) {
                             std::reference_wrapper<const RawParameterType> local_event =
-                                std::any_cast<std::reference_wrapper<const RawParameterType>>(
+                                ::access_event_value<event_type, RawParameterType>(
                                     std::move(value));
 
+                            // Check if the event type is an rvalue reference and handle accordingly
                             if constexpr (std::is_rvalue_reference_v<EventType>) {
                                 static_assert(std::is_copy_constructible_v<RawParameterType>,
                                               "Event type must be copy constructible.");
@@ -265,29 +303,21 @@ namespace dp {
         }
     };
 
-    inline const void* handler_registration::handle() const noexcept { return handle_; }
+    using handler_registration = event_bus_impl<>::handler_registration;
 
-    inline void handler_registration::unregister() noexcept {
-        if (event_bus_ && handle_) {
-            event_bus_->remove_handler(*this);
-            handle_ = nullptr;
-        }
+    /**
+     * @brief Default event_bus implementation uses the default storage policy.
+     */
+    using event_bus = event_bus_impl<default_event_bus_storage_policy>;
+
+    /**
+     * @brief Create an event bus for a given set of event types.
+     * @tparam Events The event types to be used with the event bus.
+     * @return An instance of event_bus_impl using the std::variant storage policy.
+     */
+    template <typename... Events>
+    auto make_event_bus_for_types()
+        -> event_bus_impl<detail::variant_event_bus_storage_policy<Events...>> {
+        return dp::event_bus_impl<detail::variant_event_bus_storage_policy<Events...>>();
     }
-
-    inline handler_registration::handler_registration(const void* handle,
-                                                      dp::event_bus* bus) noexcept
-        : handle_(handle), event_bus_(bus) {}
-
-    inline handler_registration::handler_registration(handler_registration&& other) noexcept
-        : handle_(std::exchange(other.handle_, nullptr)),
-          event_bus_(std::exchange(other.event_bus_, nullptr)) {}
-
-    inline handler_registration& handler_registration::operator=(
-        handler_registration&& other) noexcept {
-        handle_ = std::exchange(other.handle_, nullptr);
-        event_bus_ = std::exchange(other.event_bus_, nullptr);
-        return *this;
-    }
-
-    inline handler_registration::~handler_registration() noexcept { unregister(); }
 }  // namespace dp

--- a/eventbus/include/eventbus/event_bus.hpp
+++ b/eventbus/include/eventbus/event_bus.hpp
@@ -52,6 +52,10 @@ namespace dp {
                   event_bus_(std::exchange(other.event_bus_, nullptr)) {}
 
             handler_registration& operator=(handler_registration&& other) noexcept {
+                if(this == &other) {
+                    return *this;
+                }
+                
                 handle_ = std::exchange(other.handle_, nullptr);
                 event_bus_ = std::exchange(other.event_bus_, nullptr);
                 return *this;

--- a/eventbus/include/eventbus/event_bus.hpp
+++ b/eventbus/include/eventbus/event_bus.hpp
@@ -32,8 +32,8 @@ namespace dp {
     /**
      * @brief A central event handler class that connects event handlers with the events.
      */
-    template <typename StoragePolicy = default_event_bus_storage_policy>
-    class event_bus_impl {
+    template <typename... EventTypes>
+    class event_bus {
       public:
         /**
          * @brief A registration handle for a particular handler of an event type.
@@ -44,7 +44,7 @@ namespace dp {
          */
         class handler_registration {
             const void* handle_{nullptr};
-            dp::event_bus_impl<StoragePolicy>* event_bus_{nullptr};
+            dp::event_bus<EventTypes...>* event_bus_{nullptr};
 
           public:
             handler_registration(handler_registration&& other) noexcept
@@ -52,10 +52,10 @@ namespace dp {
                   event_bus_(std::exchange(other.event_bus_, nullptr)) {}
 
             handler_registration& operator=(handler_registration&& other) noexcept {
-                if(this == &other) {
+                if (this == &other) {
                     return *this;
                 }
-                
+
                 handle_ = std::exchange(other.handle_, nullptr);
                 event_bus_ = std::exchange(other.event_bus_, nullptr);
                 return *this;
@@ -80,18 +80,22 @@ namespace dp {
             }
 
           protected:
-            handler_registration(const void* handle,
-                                 dp::event_bus_impl<StoragePolicy>* bus) noexcept
+            handler_registration(const void* handle, dp::event_bus<EventTypes...>* bus) noexcept
                 : handle_(handle), event_bus_(bus) {}
-            friend class event_bus_impl;
+            friend class event_bus;
         };
 
         /// @brief Public type aliases
         /// @{
+        using StoragePolicy =
+            std::conditional_t<sizeof...(EventTypes) == 0, detail::any_event_bus_storage_policy,
+                               detail::variant_event_bus_storage_policy<EventTypes...>>;
         using event_type = typename StoragePolicy::event_type;
         using event_handler = typename StoragePolicy::event_handler;
-        using handler_registration = typename event_bus_impl::handler_registration;
+        using handler_registration = typename event_bus::handler_registration;
         /// @}
+
+        event_bus() = default;
 
         /**
          * @brief Register an event handler for a given event type.
@@ -307,21 +311,9 @@ namespace dp {
         }
     };
 
-    using handler_registration = event_bus_impl<>::handler_registration;
+    /// @brief CTAD guide for dp::event_bus
+    template <typename T = void>
+    event_bus() -> event_bus<>;
 
-    /**
-     * @brief Default event_bus implementation uses the default storage policy.
-     */
-    using event_bus = event_bus_impl<default_event_bus_storage_policy>;
-
-    /**
-     * @brief Create an event bus for a given set of event types.
-     * @tparam Events The event types to be used with the event bus.
-     * @return An instance of event_bus_impl using the std::variant storage policy.
-     */
-    template <typename... Events>
-    auto make_event_bus_for_types()
-        -> event_bus_impl<detail::variant_event_bus_storage_policy<Events...>> {
-        return dp::event_bus_impl<detail::variant_event_bus_storage_policy<Events...>>();
-    }
+    using handler_registration = event_bus<>::handler_registration;
 }  // namespace dp

--- a/eventbus/include/eventbus/event_bus.hpp
+++ b/eventbus/include/eventbus/event_bus.hpp
@@ -22,7 +22,7 @@ namespace {
         if constexpr (dp::detail::is_any<Event>::value) {
             return std::any_cast<std::reference_wrapper<const RawParameterType>>(value);
         } else {
-            return std::cref(std::get<RawParameterType>(value));
+            return std::get<std::reference_wrapper<const RawParameterType>>(value);
         }
     }
 }  // namespace
@@ -284,7 +284,7 @@ namespace dp {
                         type_idx, [func = std::forward<EventHandler>(handler)](event_type&& value) {
                             std::reference_wrapper<const RawParameterType> local_event =
                                 ::access_event_value<event_type, RawParameterType>(
-                                    std::move(value));
+                                    std::forward<event_type>(value));
 
                             // Check if the event type is an rvalue reference and handle accordingly
                             if constexpr (std::is_rvalue_reference_v<EventType>) {

--- a/eventbus/test/event_bus_tests.cpp
+++ b/eventbus/test/event_bus_tests.cpp
@@ -82,7 +82,8 @@ TEST_CASE("deregister while dispatching") {
         evt_bus.register_handler<test_event_type>(&counter, &event_handler_counter::on_test_event);
 
     struct deregister_while_dispatch_listener {
-        dp::event_bus* evt_bus{nullptr};
+        // CTAD not allowed in non-static struct members so we have to include the empty brackets
+        dp::event_bus<>* evt_bus{nullptr};
         std::vector<dp::handler_registration>* registrations{nullptr};
         void on_event(test_event_type) {
             if (evt_bus && registrations) {
@@ -244,7 +245,7 @@ TEST_CASE("event_bus_variant: multi-threaded event dispatch") {
         }
     };
 
-    auto evt_bus = dp::make_event_bus_for_types<test_event_type>();
+    dp::event_bus<test_event_type> evt_bus{};
 
     simple_listener listener_one(1);
     simple_listener listener_two(2);
@@ -289,7 +290,7 @@ TEST_CASE("event_bus_variant: basic multi-event support") {
         char character;
     };
 
-    auto evt_bus = dp::make_event_bus_for_types<event1, event2, event3>();
+    dp::event_bus<event1, event2, event3> evt_bus{};
     event_handler_counter event_counter;
     auto event_handler_reg =
         evt_bus.register_handler<event1>(&event_counter, &event_handler_counter::on_test_event);

--- a/eventbus/test/event_bus_tests.cpp
+++ b/eventbus/test/event_bus_tests.cpp
@@ -4,6 +4,8 @@
 #include <atomic>
 #include <eventbus/event_bus.hpp>
 #include <iostream>
+#include <optional>
+#include <sstream>
 #include <thread>
 struct test_event_type {
     int id{-1};

--- a/eventbus/test/event_bus_tests.cpp
+++ b/eventbus/test/event_bus_tests.cpp
@@ -5,7 +5,6 @@
 #include <eventbus/event_bus.hpp>
 #include <iostream>
 #include <thread>
-
 struct test_event_type {
     int id{-1};
     std::string event_message;
@@ -229,4 +228,102 @@ TEST_CASE("Ensure events are not unnecessarily copied") {
     evt_bus.fire_event(const_checker);
 
     CHECK_FALSE(event_copied);
+}
+
+TEST_CASE("event_bus_variant: multi-threaded event dispatch") {
+    class simple_listener {
+        int index_;
+
+      public:
+        explicit simple_listener(int index) : index_(index) {}
+        void on_event(const test_event_type& evt) const {
+            std::cout << "simple event: " << index_ << " " << evt.event_message << "\n";
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    };
+
+    auto evt_bus = dp::make_event_bus_for_types<test_event_type>();
+
+    simple_listener listener_one(1);
+    simple_listener listener_two(2);
+
+    auto reg_one = evt_bus.register_handler(&listener_one, &simple_listener::on_event);
+    auto reg_two = evt_bus.register_handler(&listener_two, &simple_listener::on_event);
+
+    event_handler_counter event_counter;
+    auto event_handler_reg = evt_bus.register_handler<test_event_type>(
+        &event_counter, &event_handler_counter::on_test_event);
+
+    auto thread_one = std::thread([&evt_bus, &listener_one]() {
+        for (auto i = 0; i < 5; ++i) {
+            evt_bus.fire_event(test_event_type{3, "thread_one", 1.0});
+        }
+    });
+
+    auto thread_two = std::thread([&evt_bus, &listener_two]() {
+        for (auto i = 0; i < 5; ++i) {
+            evt_bus.fire_event(test_event_type{3, "thread_two", 2.0});
+        }
+    });
+
+    thread_one.join();
+    thread_two.join();
+
+    // include the event counter
+    CHECK_EQ(evt_bus.handler_count(), 3);
+
+    CHECK_EQ(event_counter.get_count(), 10);
+}
+
+TEST_CASE("event_bus_variant: basic multi-event support") {
+    struct event1 {
+        int id;
+        std::string message;
+    };
+    struct event2 {
+        double value;
+    };
+    struct event3 {
+        char character;
+    };
+
+    auto evt_bus = dp::make_event_bus_for_types<event1, event2, event3>();
+    event_handler_counter event_counter;
+    auto event_handler_reg =
+        evt_bus.register_handler<event1>(&event_counter, &event_handler_counter::on_test_event);
+    auto event_handler_reg2 =
+        evt_bus.register_handler<event2>(&event_counter, &event_handler_counter::on_test_event);
+    auto event_handler_reg3 =
+        evt_bus.register_handler<event3>(&event_counter, &event_handler_counter::on_test_event);
+
+    struct conglomerate_handler {
+        void ev1(const event1& evt) { e1 = evt; }
+        void ev2(const event2& evt) { e2 = evt; }
+        void ev3(const event3& evt) { e3 = evt; }
+
+        std::optional<event1> e1;
+        std::optional<event2> e2;
+        std::optional<event3> e3;
+
+        auto combine() -> std::string {
+            REQUIRE(e1.has_value());
+            REQUIRE(e2.has_value());
+            REQUIRE(e3.has_value());
+            std::stringstream oss;
+            oss << e1->id << " " << e1->message << " | " << e2->value << " | " << e3->character;
+            return oss.str();
+        }
+    };
+
+    conglomerate_handler handler;
+    auto registration = evt_bus.register_handler(&handler, &conglomerate_handler::ev1);
+    auto registration2 = evt_bus.register_handler(&handler, &conglomerate_handler::ev2);
+    auto registration3 = evt_bus.register_handler(&handler, &conglomerate_handler::ev3);
+
+    evt_bus.fire_event(event1{1, "Hello"});
+    evt_bus.fire_event(event2{3.14});
+    evt_bus.fire_event(event3{'A'});
+
+    CHECK_EQ(handler.combine(), "1 Hello | 3.14 | A");
+    CHECK_EQ(event_counter.get_count(), 3);
 }


### PR DESCRIPTION
# Changes
- Added support to choose storage policy of event types as either `std::any` or `std::variant`
- Added initial MacOS support in `CMakePresets.json`
- New options in CMake to control building demo, tests and benchmarks
- Added benchmark for comparing event dispatch between `std::any` and `std::variant`

@thejtshow Please take a look if you can. Thanks!

Resolves #33 